### PR TITLE
Prevent double bid & Invest-Sniper for specific players

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -5,7 +5,7 @@ FUTBOT_FUT_API_ENDPOINT_OVERWRITE=https://utas.external.s2.fut.ea.com/ut/game/fi
 # remove '#' infront of FUTBOT_FUT_PLATFORM_OVERWRITE if you wish to set manually
 # FUTBOT_FUT_PLATFORM_OVERWRITE=pc
 
-# Pages to see lowest price target in low player invest. Higher = more risk that someone else buys it
+# Attempts to find a cheap-trade per player
 FUTBOT_FUT_MAX_AUCTION_TRY_PER_PLAYER=1
 
 # Amount of minimum market auctions to calculate price of a player. Higher the value, more correct price
@@ -28,6 +28,6 @@ FUTBOT_FAVOURITE_JOBS=/trade-bot/start-selling-trade-pile,/invest/low-players?bu
 # Speed up factor will be used to automatically slow down/speed up api calls. Leave it as 0.2 if you don't know what you are doing
 FUTBOT_API_QUEUE_SPEED_UP_FACTOR=0.2
 
-# Profit margin percentage to use in invest jobs. Should be between 5-20 for efficiency. 
+# Profit margin percentage to use in invest jobs. Should be between 5-20 for efficiency.
 # 20 means the bot will try to buy someone valued 1000 coins for 800 coins
 FUTBOT_PROFIT_MARGIN=15

--- a/lib/api/api-queue.ts
+++ b/lib/api/api-queue.ts
@@ -88,6 +88,7 @@ export class ApiQueue {
         !!this.configResolver ? this.configResolver(config) : config
       );
     }
+
     return new Promise(async (resolve, reject) => {
       const queueTime = new Date().getTime();
       this.queue.push({
@@ -135,7 +136,7 @@ export class ApiQueue {
     if (this.queue.length > MAX_OPTIMUM_QUEUE_LENGTH) {
       this.queueCheckOptimalCount = 0;
       logger.warn(
-        `Queue for ${this.apiName} is bloated(${this.queue.length} requests waiting). Pausing jobs for a minute and slowing by ${SPEED_UP_FACTOR}`
+        `Queue for ${this.apiName} is bloated (${this.queue.length} requests waiting). Pausing jobs for a minute and slowing by ${SPEED_UP_FACTOR}`
       );
       Job.stopAllJobs();
       Job.changeJobSpeedsBy(1 - SPEED_UP_FACTOR);

--- a/lib/invest/invest-app.ts
+++ b/lib/invest/invest-app.ts
@@ -3,15 +3,45 @@ import { investService } from './invest-service';
 
 export const investApp = express();
 
+investApp.get('/snipe-player', async (req, res) => {
+  const { player } = req.query;
+  let { budget } = req.query;
+  budget = parseInt(budget, 10);
+
+  const maxTargetPool = 1;
+  const min = 0;
+  const max = budget;
+
+  if (!budgetMinMaxQueryCheck(res, budget, min, max)) {
+    return;
+  }
+
+  res.send(
+    investService.startLowPlayerInvest({
+      budget,
+      min,
+      max,
+      maxTargetPool,
+      player
+    })
+  );
+});
+
 investApp.get('/low-players', async (req, res) => {
-  const { maxTargetPool } = req.query;
+  const { maxTargetPool, player } = req.query;
   const { budget, min, max } = getBudgetMinMax(req.query);
   if (!budgetMinMaxQueryCheck(res, budget, min, max)) {
     return;
   }
 
   res.send(
-    investService.startLowPlayerInvest({ budget, min, max, maxTargetPool })
+    investService.startLowPlayerInvest({
+      budget,
+      min,
+      max,
+      maxTargetPool,
+      player
+    })
   );
 });
 

--- a/lib/invest/invest-service.ts
+++ b/lib/invest/invest-service.ts
@@ -18,7 +18,8 @@ export namespace investService {
   }
 
   export async function getTargets(
-    query: futbin.PlayersQuery
+    query: futbin.PlayersQuery,
+    player?: number
   ): Promise<TargetInfo[]> {
     const platform = await fut.getPlatform();
     const priceKey = `${platform.toLowerCase()}_price`;
@@ -40,7 +41,7 @@ export namespace investService {
       delete q[prpKey];
     }
 
-    const playerIds = await futbin.getPlayerIDs(q as any);
+    const playerIds = !!player ? [player] : await futbin.getPlayerIDs(q as any);
     logger.debug(`[InvestService]: Target ids: ${playerIds}`);
 
     const playerInfos: TargetInfo[] = [];

--- a/lib/invest/jobs/low-player-investor.ts
+++ b/lib/invest/jobs/low-player-investor.ts
@@ -116,12 +116,12 @@ export class LowPlayerInvestor extends Job {
       return;
     }
 
+    const triedAuctions = [];
     const maxAuctionTry = !this.player ? MAX_AUCTION_TRY : MAX_AUCTION_TRY * 2;
     const safeBuyValue = tradePrice(
       sellPrice.buyNowPrice * BUY_REFERENCE_PERCT
     );
 
-    let triedAuctions = [];
     let batch = 0;
     while (true) {
       if (batch >= maxAuctionTry) {

--- a/lib/jobs/job.ts
+++ b/lib/jobs/job.ts
@@ -65,7 +65,7 @@ export class Job {
       return;
     }
 
-    logger.debug(`Stoping job ${this.id}`);
+    logger.debug(`Stopping job ${this.id}`);
     this.sub.unsubscribe();
     delete this.sub;
   }
@@ -89,7 +89,7 @@ export class Job {
     this.sub = this.source.subscribe(async () => {
       if (this.executing) {
         logger.warn(
-          `${this.id} was to slow to execute on previos run. Skipping this one.`
+          `${this.id} was to slow to execute on previous run. Skipping this one.`
         );
         return;
       }

--- a/lib/player/player-service.ts
+++ b/lib/player/player-service.ts
@@ -33,6 +33,11 @@ export namespace playerService {
         return;
       }
 
+      // ignore the default buy-now price
+      if (a.buyNowPrice === a.itemData.marketDataMaxPrice) {
+        return;
+      }
+
       if (a.buyNowPrice < price.minBuyNow) {
         price.minBuyNow = a.buyNowPrice;
       }

--- a/lib/trader/trade-utils.ts
+++ b/lib/trader/trade-utils.ts
@@ -38,7 +38,7 @@ export function getFutbinSellPrice(price: futbin.Price): SellPrice {
   }
 
   // ignore old prices
-  if (price.updatedMinsAgo === -1 || price.updatedMinsAgo > 12 * 60) {
+  if (price.updatedMinsAgo === -1 || price.updatedMinsAgo > 60) {
     return null;
   }
 


### PR DESCRIPTION
Hi there :),

- added a filter to prevent double bids on the same trade (if using FUTBOT_FUT_MAX_AUCTION_TRY_PER_PLAYER)
- also filter trades that are old (less then 30min left) - if such trades would have been selected, i experience losses because of bad price-assumptions

I've also added a sniper to the invest-app, to target a specific player that might be super hot. Worked quite good sometimes.